### PR TITLE
Add package auto discovery for laravel 5.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,19 @@ Require the `jowusu837/laravelhubtelmerchantaccount` package in your `composer.j
 ```sh
 $ composer require jowusu837/laravelhubtelmerchantaccount
 ```
+If you're using Laravel 5.5, this is all there is to do.
 
-Add the HubtelMerchantAccount\ServiceProvider to your `config/app.php` providers array:
+Should you still be on older versions of Laravel, the final steps for you are to add the service provider of the package and alias the package. To do this open your `config/app.php` file.
+
+Add the HubtelMerchantAccount\ServiceProvider to your `providers` array:
 ```php
 Jowusu837\HubtelMerchantAccount\ServiceProvider::class,
 ```
-Add facade
+And add a new line to the `aliases` array:
 ```php
 'aliases' => [
       ...
-      HubtelMerchantAccount' => Jowusu837\HubtelMerchantAccount\HubtelMerchantAccountFacade::class,
+      'HubtelMerchantAccount' => Jowusu837\HubtelMerchantAccount\HubtelMerchantAccountFacade::class,
       ...
  ]
 ```

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,15 @@
       "Jowusu837\\HubtelMerchantAccount\\": "src"
     }
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "extra": {
+    "laravel": {
+        "providers": [
+            "Jowusu837\\HubtelMerchantAccount\\ServiceProvider"
+        ],
+        "aliases": {
+            "HubtelMerchantAccount": "Jowusu837\\HubtelMerchantAccount\\HubtelMerchantAccountFacade"
+        }
+    }
+  }
 }


### PR DESCRIPTION
Laravel 5.5+ ships with auto package discovery which automates the addition of ServiceProviders and Aliases to the `config/app.php`. This pull request adds this feature to this package to enable users running on Laravel 5.5+ enjoy it. Users on older versions can however still use the package but must still add the Providers and Aliases to the `config/app.php` file.