### PR TITLE
Fix receiveMobileMoney content type bug

### DIFF
--- a/src/Helpers/FormatsRequest.php
+++ b/src/Helpers/FormatsRequest.php
@@ -20,4 +20,22 @@ trait FormatsRequests
         }
         return json_encode($json);
     }
+
+    public function flattern($array)
+    {
+        $flattened = array();
+        if(!is_array($array))
+        {
+            throw new InvalidArgumentException('flattern flatterns only arrays');
+        }
+        foreach ($array as $value) {
+			if(!is_array($value))
+			{
+                if(!is_null($value)) $flattened[] = $value;
+			}else{
+				$flattened = array_merge($flattened,$this->flattern($value));
+			}
+        }
+        return $flattened;
+    }
 }

--- a/src/Helpers/FormatsRequest.php
+++ b/src/Helpers/FormatsRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jowusu837\HubtelMerchantAccount\Helpers;
+
+trait FormatsRequests
+{
+    public function toJson($object)
+    {
+        $json = array();
+        if(!is_object($object))
+        {
+            throw new InvalidArgumentException('toJson formats only objects');
+        }
+        foreach(get_object_vars($object) as $property => $value )
+        {
+            if(!is_null($value))
+            {
+                $json[$property] = $value;
+            }
+        }
+        return json_encode($json);
+    }
+}

--- a/src/MerchantAccount.php
+++ b/src/MerchantAccount.php
@@ -9,10 +9,11 @@
 namespace Jowusu837\HubtelMerchantAccount;
 
 use GuzzleHttp\Client;
+use Jowusu837\HubtelMerchantAccount\Helpers\FormatsRequests;
+use Jowusu837\HubtelMerchantAccount\ReceiveMobileMoneyResponse;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Request as OnlineCheckoutRequest;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Response as OnlineCheckoutResponse;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\InvoiceStatusResponse as OnlineCheckoutInvoiceStatusResponse;
-use Jowusu837\HubtelMerchantAccount\Helpers\FormatsRequests;
 
 class MerchantAccount
 {
@@ -51,8 +52,8 @@ class MerchantAccount
         if ($response->getStatusCode() !== 200) {
             throw new \Exception((string)$response->getBody());
         }
-
-        return json_decode((string)$response->getBody());
+        
+        return new ReceiveMobileMoneyResponse(...$this->flattern(json_decode((string)$response->getBody(),true)));
     }
 
 //    public function sendMobileMoney()

--- a/src/MerchantAccount.php
+++ b/src/MerchantAccount.php
@@ -12,10 +12,12 @@ use GuzzleHttp\Client;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Request as OnlineCheckoutRequest;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Response as OnlineCheckoutResponse;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\InvoiceStatusResponse as OnlineCheckoutInvoiceStatusResponse;
-
+use Jowusu837\HubtelMerchantAccount\Helpers\FormatsRequests;
 
 class MerchantAccount
 {
+    use FormatsRequests;
+
     /** @var array */
     protected $config;
 
@@ -39,7 +41,10 @@ class MerchantAccount
         $http = new Client(['base_uri' => 'https://api.hubtel.com']);
 
         $response = $http->request('POST', "/v1/merchantaccount/merchants/{$this->config['account_number']}/receive/mobilemoney", [
-            'json' => json_decode($request, true),
+            'headers'=>[
+                'Content-type' => 'application/json'
+            ],
+            'body' => $this->toJson($request),
             'auth' => [$this->config['api_key']['client_id'], $this->config['api_key']['client_secret']]
         ]);
 

--- a/src/ReceiveMobileMoneyResponse.php
+++ b/src/ReceiveMobileMoneyResponse.php
@@ -5,13 +5,67 @@ namespace Jowusu837\HubtelMerchantAccount;
 
 class ReceiveMobileMoneyResponse
 {
-    public $Amount;
-    public $Charges;
-    public $AmountAfterCharges;
-    public $TransactionId;
-    public $ResponseCode;
-    public $Description;
-    public $ClientReference;
-    public $ExternalTransactionId;
-    public $AmountCharged;
+    protected $ResponseCode;
+    protected $AmountAfterCharges;
+    protected $TransactionId;
+    protected $ClientReference;
+    protected $Description;
+    protected $ExternalTransactionId;
+    protected $Amount;
+    protected $Charges;
+
+    public function __construct($ResponseCode = null, $AmountAfterCharges = null, $TransactionId = null,
+     $ClientReference = null, $Description = null, $ExternalTransactionId = null,
+     $Amount = null, $Charges = null
+    )
+     {
+        $this->Amount = $Amount;
+        $this->Charges = $Charges;
+        $this->AmountAfterCharges = $AmountAfterCharges;
+        $this->TransactionId = $TransactionId;
+        $this->ResponseCode = $ResponseCode;
+        $this->Description = $Description;
+        $this->ClientReference = $ClientReference;
+        $this->ExternalTransactionId = $ExternalTransactionId;
+     }
+
+     public function Amount()
+     {
+         return $this->Amount;
+     }
+
+     public function Charges()
+     {
+         return $this->Charges;
+     }
+
+     public function AmountAfterCharges()
+     {
+         return $this->AmountAfterCharges;
+     }
+
+     public function TransactionId()
+     {
+         return $this->TransactionId;
+     }
+
+     public function ResponseCode()
+     {
+         return $this->ResponseCode;
+     }
+
+     public function Description()
+     {
+         return $this->Description;
+     }
+
+     public function ClientReference()
+     {
+         return $this->ClientReference;
+     }
+
+     public function ExternalTransactionId()
+     {
+         return $this->ExternalTransactionId;
+     }
 }


### PR DESCRIPTION
The package sends a `POST` request to the mobilemoney endpoint using `'json' => json_decode($request, true),`  as the body of the request. However the `receiveMobileMoney` method recieves and instance of `ReceiveMobileMoneyRequest` and is passing a `json_decode` of the object(ReceiveMobileMoneyRequest $request) to the body of the request. This throws an error because `json_decode` expects a string as a parameter and not an object. This pull request ships with a new `Helpers/FormatsRequests.php` file with methods which takes an object and returns all the public not null properties of the object and returns it either in `json` or as an `array`. Also this pull request changes the `json` option on the `request` and replaces it with the `body` and states the `headers` explicitly