### PR TITLE
Extract requests from Merchant account to a dedicated class

### DIFF
--- a/src/Helpers/SendsRequests.php
+++ b/src/Helpers/SendsRequests.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Jowusu837\HubtelMerchantAccount\Helpers;
+
+use GuzzleHttp\Client;
+use Jowusu837\HubtelMerchantAccount\Helpers\FormatsRequests;
+use Jowusu837\HubtelMerchantAccount\ReceiveMobileMoneyRequest;
+use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Request as OnlineCheckoutRequest;
+
+class SendsRequests
+{
+    use FormatsRequests;
+
+    protected $http;
+
+    protected $config;
+
+    private $auth;
+
+    public function __construct($config)
+    {
+        $this->http = new Client(['base_uri' => 'https://api.hubtel.com']);
+        $this->config = $config;
+        $this->auth = [$this->config['api_key']['client_id'], $this->config['api_key']['client_secret']];
+    }
+
+    public function sendReceiveMobileMoneyRequest(ReceiveMobileMoneyRequest $request)
+    {
+        $response = $this->http->request('POST', "/v1/merchantaccount/merchants/{$this->config['account_number']}/receive/mobilemoney", [
+            'headers'=>[
+                'Content-type' => 'application/json'
+            ],
+            'body' => $this->toJson($request),
+            'auth' => $this->auth
+        ]);   
+        
+        $this->checkResponseStatus($response);
+
+        return $this->flattern(json_decode((string)$response->getBody(),true));
+    }
+
+    public function sendOnlineCheckoutRequest(OnlineCheckoutRequest $request)
+    {
+        if (!$request->store->name) {
+            $request->store->name = $this->config['store']['name'];
+        }
+
+        $response = $this->http->request('POST', "/v1/merchantaccount/onlinecheckout/invoice/create", [
+            'json' => json_decode(json_encode($request), true),
+            'auth' => $this->auth
+        ]);
+
+        $this->checkResponseStatus($response);
+
+        $invoiceResponse = json_decode((string)$response->getBody());
+        
+        return $invoiceResponse->response_text;
+    }
+
+    public function sendCheckInvoiceStatusRequest($token)
+    {
+        $response = $this->http->request('GET', "/v1/merchantaccount/onlinecheckout/invoice/status/{$token}");
+        
+        $this->checkResponseStatus($response);
+        
+        return json_decode((string)$response->getBody());
+    }
+
+    private function checkResponseStatus($response)
+    {
+        if ($response->getStatusCode() !== 200) {
+            throw new \Exception((string)$response->getBody());
+        }
+        return $this;
+    }
+}

--- a/src/MerchantAccount.php
+++ b/src/MerchantAccount.php
@@ -9,7 +9,7 @@
 namespace Jowusu837\HubtelMerchantAccount;
 
 use GuzzleHttp\Client;
-use Jowusu837\HubtelMerchantAccount\Helpers\FormatsRequests;
+use Jowusu837\HubtelMerchantAccount\Helpers\SendsRequests;
 use Jowusu837\HubtelMerchantAccount\ReceiveMobileMoneyResponse;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Request as OnlineCheckoutRequest;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Response as OnlineCheckoutResponse;
@@ -17,17 +17,15 @@ use Jowusu837\HubtelMerchantAccount\OnlineCheckout\InvoiceStatusResponse as Onli
 
 class MerchantAccount
 {
-    use FormatsRequests;
-
-    /** @var array */
-    protected $config;
+    /** @var SendsRequests */
+    protected $http;
 
     /**
      * @param array $config
      */
-    public function __construct($config)
+    public function __construct(SendsRequests $http)
     {
-        $this->config = $config;
+        $this->http = $http;
     }
 
     /**
@@ -39,21 +37,8 @@ class MerchantAccount
      */
     public function receiveMobileMoney(ReceiveMobileMoneyRequest $request)
     {
-        $http = new Client(['base_uri' => 'https://api.hubtel.com']);
-
-        $response = $http->request('POST', "/v1/merchantaccount/merchants/{$this->config['account_number']}/receive/mobilemoney", [
-            'headers'=>[
-                'Content-type' => 'application/json'
-            ],
-            'body' => $this->toJson($request),
-            'auth' => [$this->config['api_key']['client_id'], $this->config['api_key']['client_secret']]
-        ]);
-
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception((string)$response->getBody());
-        }
-        
-        return new ReceiveMobileMoneyResponse(...$this->flattern(json_decode((string)$response->getBody(),true)));
+        $response = $this->http->sendReceiveMobileMoneyRequest($request);
+        return new ReceiveMobileMoneyResponse(...$response);
     }
 
 //    public function sendMobileMoney()
@@ -75,24 +60,8 @@ class MerchantAccount
      */
     public function onlineCheckout(OnlineCheckoutRequest $request)
     {
-        if (!$request->store->name) {
-            $request->store->name = $this->config['store']['name'];
-        }
-
-        $http = new Client(['base_uri' => 'https://api.hubtel.com']);
-
-        $response = $http->request('POST', "/v1/merchantaccount/onlinecheckout/invoice/create", [
-            'json' => json_decode(json_encode($request), true),
-            'auth' => [$this->config['api_key']['client_id'], $this->config['api_key']['client_secret']]
-        ]);
-
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception((string)$response->getBody());
-        }
-
-        $invoiceResponse = json_decode((string)$response->getBody());
-
-        return header('Location: ' . $invoiceResponse->response_text);;
+        $checkout_url = $this->http->sendOnlineCheckoutRequest($request);
+        return header('Location: ' . $checkout_url);;
     }
 
     /**
@@ -104,15 +73,8 @@ class MerchantAccount
      */
     public function checkInvoiceStatus($token)
     {
-        $http = new Client(['base_uri' => 'https://api.hubtel.com']);
-
-        $response = $http->request('GET', "/v1/merchantaccount/onlinecheckout/invoice/status/{$token}");
-
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception((string)$response->getBody());
-        }
-
-        return json_decode((string)$response->getBody());
+        $response = $this->http->sendCheckInvoiceStatusRequest($token);
+        return $response;
     }
 
 //    public function transactionStatus()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Jowusu837\HubtelMerchantAccount;
 
+use Jowusu837\HubtelMerchantAccount\Helpers\SendsRequests;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 
@@ -32,7 +33,7 @@ class ServiceProvider extends BaseServiceProvider
         $this->mergeConfigFrom($this->configPath(), 'hubtelmerchantaccount');
 
         $this->app->singleton(MerchantAccount::class, function($app){
-            return new MerchantAccount($app['config']->get('hubtelmerchantaccount'));
+            return new MerchantAccount(new SendsRequests($app['config']->get('hubtelmerchantaccount')));
         });
 
         $this->app->alias(MerchantAccount::class, 'HubtelMerchantAccount');


### PR DESCRIPTION
I think the `MerchantAccount` class should not care about how the `Requests` are sent, instead all it should do is know that `Requests` are sent and is expecting a `Response`. This pull request extracts all requests from the `MerchantAccount` to a dedicated class `SendsRequests` in the Helpers directory. This class is in charge of sending and formatting the requests. When this pull request is accepted, all the `MerchantAccount`  class would do is the create the responses for each request type 
eg.
```php
   public function receiveMobileMoney(ReceiveMobileMoneyRequest $request)
    {
        $response = $this->http->sendReceiveMobileMoneyRequest($request);
        return new ReceiveMobileMoneyResponse(...$response);
    }
```
After this pull request is accepted, i would like to suggest that subsequent requests should be defined in the `SendsRequests` class instead of the `MerchantAccount`