### PR TITLE
Implement Refund Mobile Money

### DIFF
--- a/src/Helpers/SendsRequests.php
+++ b/src/Helpers/SendsRequests.php
@@ -3,6 +3,7 @@
 namespace Jowusu837\HubtelMerchantAccount\Helpers;
 
 use GuzzleHttp\Client;
+use Jowusu837\HubtelMerchantAccount\RefundRequest;
 use Jowusu837\HubtelMerchantAccount\Helpers\FormatsRequests;
 use Jowusu837\HubtelMerchantAccount\ReceiveMobileMoneyRequest;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Request as OnlineCheckoutRequest;
@@ -64,6 +65,19 @@ class SendsRequests
         $this->checkResponseStatus($response);
         
         return json_decode((string)$response->getBody());
+    }
+
+    public function sendRefundMobileMoneyRequest(RefundRequest $request)
+    {
+        $response = $this->http->request('POST', "/v1/merchantaccount/merchants/{$this->config['account_number']}/transactions/refund", [
+            'headers'=>[
+                'Content-type' => 'application/json'
+            ],
+            'body' => $this->toJson($request),
+            'auth' => $this->auth
+        ]); 
+        $this->checkResponseStatus($response);
+        return $this->flattern(json_decode((string)$response->getBody(),true)); 
     }
 
     private function checkResponseStatus($response)

--- a/src/MerchantAccount.php
+++ b/src/MerchantAccount.php
@@ -9,6 +9,8 @@
 namespace Jowusu837\HubtelMerchantAccount;
 
 use GuzzleHttp\Client;
+use Jowusu837\HubtelMerchantAccount\RefundRequest;
+use Jowusu837\HubtelMerchantAccount\RefundResponse;
 use Jowusu837\HubtelMerchantAccount\Helpers\SendsRequests;
 use Jowusu837\HubtelMerchantAccount\ReceiveMobileMoneyResponse;
 use Jowusu837\HubtelMerchantAccount\OnlineCheckout\Request as OnlineCheckoutRequest;
@@ -46,10 +48,11 @@ class MerchantAccount
 //        throw new \Exception("Method not yet implemented");
 //    }
 //
-//    public function refundMobileMoney()
-//    {
-//        throw new \Exception("Method not yet implemented");
-//    }
+   public function refundMobileMoney(RefundRequest $request)
+   {
+        $response = $this->http->sendRefundMobileMoneyRequest($request);
+        return new RefundResponse(...$response);
+   }
 
     /**
      * Online checkout

--- a/src/ReceiveMobileMoneyResponse.php
+++ b/src/ReceiveMobileMoneyResponse.php
@@ -14,9 +14,9 @@ class ReceiveMobileMoneyResponse
     protected $Amount;
     protected $Charges;
 
-    public function __construct($ResponseCode = null, $AmountAfterCharges = null, $TransactionId = null,
-     $ClientReference = null, $Description = null, $ExternalTransactionId = null,
-     $Amount = null, $Charges = null
+    public function __construct($ResponseCode, $AmountAfterCharges, $TransactionId ,
+     $ClientReference, $Description , $ExternalTransactionId,
+     $Amount , $Charges 
     )
      {
         $this->Amount = $Amount;

--- a/src/RefundRequest.php
+++ b/src/RefundRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Jowusu837\HubtelMerchantAccount;
+
+class RefundRequest
+{
+    /**
+     * The unique ID of the mobile money 
+     * transaction you want to refund.
+     * @var string
+     */
+    public $TransactionId;
+    
+    /**
+     * A short description of your reason for 
+     * refunding the mobile money wallet.
+     * @var string
+     */
+    public $Reason;
+
+    /**
+     * A transaction reference Id from your end.
+     * @var string 
+     */
+    public$ClientReference;
+
+    /**
+     * The description.
+     * @var string
+     */
+    public $Description;
+
+    /**
+     * The amount of money you're refunding.
+     * @var string
+     */
+    public $Amount;
+
+    /**
+     * Specify if you want to make a full or
+     *  a partial refund.
+     * @var string
+     */
+    public $Full;   
+}

--- a/src/RefundResponse.php
+++ b/src/RefundResponse.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jowusu837\HubtelMerchantAccount;
+
+class RefundResponse
+{
+    protected $ResponseCode;
+    protected $TransactionId;
+    protected $ClientReference;
+    protected $Fee;
+    protected $Amount;
+    protected $Date;
+    protected $Status;
+
+    public function __construct($ResponseCode, $TransactionId, $ClientReference, $Fee
+    , $Amount, $Date, $Status)
+    {
+        $this->ResponseCode =  $ResponseCode;
+        $this->TransactionId = $TransactionId;
+        $this->ClientReference = $ClientReference;
+        $this->Fee = $Fee;
+        $this->Amount = $Amount;
+        $this->Date = $Date;
+        $this->Status = $Status;
+    }
+
+    public function ResponseCode()
+    {
+        return $this->ResponseCode;
+    }
+
+    public function TransactionId()
+    {
+        return $this->TransactionId;
+    }
+
+    public function ClientReference()
+    {
+        return $this->ClientReference;
+    }
+
+    public function Fee()
+    {
+        return $this->Fee;
+    }
+
+    public function Amount()
+    {
+        return $this->Amount;
+    }
+
+    public function Date()
+    {
+        return $this->Date;
+    }
+
+    public function Status()
+    {
+        return $this->Status;
+    }
+}


### PR DESCRIPTION
The refundMobileMoney is commented out as not implemented. This pull request ships with two classes `RefundRequest` and `RefundResponse` which helped in implementing this feature. If this pull request is merged, users of the package would be able to refund mobile money transactions using the `refundMobileMoney` method on the `MerchantAccount`.